### PR TITLE
unknown pages returning error 500

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -29,7 +29,7 @@ function Layout({ children, menu, page, signup, neighborhoods, show, slug }) {
         </section>
         <section className={styles.right}>
           <Search />
-          {slug ? <Submenu menu={menu} page={page} /> : null}
+          {page && slug ? <Submenu menu={menu} page={page} /> : null}
           <EmailSignup content={signup} />
 
           <iframe


### PR DESCRIPTION
# Bug
when a user navigated to a bad route like /cats the page would show a 500 error.

## expected behavior
When a user visits a route like /cats where we have no content, 
the page should display a message informing the user no content was found

## UI Update

<img width="1361" alt="Screenshot 2023-02-11 at 12 59 50 PM" src="https://user-images.githubusercontent.com/119478211/218280991-e03261bf-c22c-4b22-b47f-351979370a12.png">
